### PR TITLE
fix: add script support for new frontend framework

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,11 @@ import lighthouse from "lighthouse";
 
 function buildProject(project) {
     console.log('Building project: ', project.name);
-    runCommand('pnpm i', project.path);
+    if (project.install) {
+        runCommand(project.install, project.path);
+    } else {
+        runCommand('pnpm i', project.path);
+    }
     if (project.build) {
         runCommand(project.build, project.path);
     } else {

--- a/projectList.json
+++ b/projectList.json
@@ -10,7 +10,8 @@
     },
     {
         "name":"angular",
-        "path":"app/angular-realworld-example-app"
+        "path":"app/angular-realworld-example-app",
+        "build":"\"node_modules/.bin/ng\" build --configuration production  --base-href ./"
     },
     {
         "name":"svelte",
@@ -31,5 +32,47 @@
         "path":"app/realworld-qwik",
         "build":"\"node_modules/.bin/vite\" build",
         "preview":"\"node_modules/.bin/vite\" preview"
+    },
+    {
+        "name":"ember",
+        "path":"app/ember-realworld",
+        "build":"set NODE_OPTIONS=--openssl-legacy-provider && \"node_modules/.bin/ember\" build --environment=production"
+    },
+    {
+        "name":"apprun",
+        "path":"app/apprun-realworld-example-app",
+        "preview":"\"node_modules/.bin/webpack\" serve --mode production"
+    },
+    {
+        "name":"hyperapp",
+        "path":"app/hyperapp-realworld-example-app",
+        "build":"\"node_modules/.bin/parcel\" build index.html"
+    },
+    {
+        "name":"imba",
+        "path":"app/imba-realworld-example-app"
+    },
+    {
+        "name":"riot",
+        "path":"app/riot_realworld_example_app",
+        "dist":"docs"
+    },
+    {
+        "name":"san",
+        "path":"app/san-realworld-app",
+        "build":"(if exist dist rmdir dist /Q /S) && set NODE_OPTIONS=--openssl-legacy-provider && \"node_modules/.bin/webpack\" --config=webpack.config.js --mode=production"
+    },
+    {
+        "name":"stencil",
+        "path":"app/stencil-realworld-app",
+        "dist":"www",
+        "build":"(if exist www rmdir www /S /Q) && \"node_modules/.bin/stencil\" build --prerender"
+    },
+    {
+        "name":"yew",
+        "path":"app/rust-yew-realworld-example-app",
+        "install":"cargo install wasm-pack && cargo install --locked trunk",
+        "build":"cd crates/conduit-wasm && trunk build",
+        "dist":"crates/conduit-wasm/dist"
     }
 ]


### PR DESCRIPTION
add script support for:
- apprun [url](https://github.com/gothinkster/apprun-realworld-example-app.git)
path = app/apprun-realworld-example-app

- ember
path = app/ember-realworld
[url](https://github.com/gothinkster/ember-realworld.git)

- hyperapp [url](https://github.com/kwasniew/hyperapp-realworld-example-app.git)
path = app/hyperapp-realworld-example-app

- imba [url](https://github.com/cartonalexandre/imba-realworld-example-app.git)
path = app/imba-realworld-example-app

- riot [url](https://github.com/iq3addLi/riot_realworld_example_app.git)
path = app/riot_realworld_example_app

- san [url](https://github.com/ecomfe/san-realworld-app.git)
path = app/san-realworld-app

- stencil [url](https://github.com/khaledosman/stencil-realworld-app.git)
path = app/stencil-realworld-app

- yew [url](https://github.com/jetli/rust-yew-realworld-example-app.git)
path = app/rust-yew-realworld-example-app
